### PR TITLE
bcd: Facilitate developing on 32-bit ARM

### DIFF
--- a/bcd_sys_linux.go
+++ b/bcd_sys_linux.go
@@ -1,3 +1,5 @@
+// +build !arm
+
 package bcd
 
 import (

--- a/bcd_sys_unsupported.go
+++ b/bcd_sys_unsupported.go
@@ -1,4 +1,4 @@
-// +build !linux
+// +build !linux arm
 
 package bcd
 


### PR DESCRIPTION
We conditionally compile `bcd_sys_unsupported.go` instead of
`bcd_sys_linux.go` for 32-bit ARM.

Fixes #2.
